### PR TITLE
Fix to work with eslisp 0.7.5

### DIFF
--- a/index.esl
+++ b/index.esl
@@ -32,4 +32,4 @@
    (lambda
      ()
      (var args ((. Array prototype slice call) arguments 0))
-     (return ((. this multi apply) null ((. args map) transform)))))
+     (return ((. args map) transform))))

--- a/package.json
+++ b/package.json
@@ -17,11 +17,11 @@
   "author": "Anko <an@cyan.io> (http://an.cyan.io)",
   "license": "ISC",
   "devDependencies": {
-    "eslisp": "^0.7.0",
+    "eslisp": ">=0.7.5",
     "tape": "^4.0.0"
   },
   "peerDependencies": {
-    "eslisp": "0.7.x"
+    "eslisp": ">=0.7.5"
   },
   "dependencies": {}
 }


### PR DESCRIPTION
This transform no longer works with eslisp 0.7.5 since `this.multi()` was removed. This pull request fixes that.